### PR TITLE
Return of results

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2978,6 +2978,11 @@
         }
       }
     },
+    "classnames": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
+      "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
+    },
     "clean-css": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.1.tgz",
@@ -5755,7 +5760,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": false,
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5776,12 +5782,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "resolved": false,
-          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": false,
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5796,17 +5804,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "resolved": false,
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": false,
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": false,
-          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5923,7 +5934,8 @@
         "inherits": {
           "version": "2.0.3",
           "resolved": false,
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5935,6 +5947,7 @@
           "version": "1.0.0",
           "resolved": false,
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5949,6 +5962,7 @@
           "version": "3.0.4",
           "resolved": false,
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5956,12 +5970,14 @@
         "minimist": {
           "version": "0.0.8",
           "resolved": false,
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "resolved": false,
           "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -5980,6 +5996,7 @@
           "version": "0.5.1",
           "resolved": false,
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6060,7 +6077,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "resolved": false,
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6072,6 +6090,7 @@
           "version": "1.4.0",
           "resolved": false,
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6157,7 +6176,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "resolved": false,
-          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6193,6 +6213,7 @@
           "version": "1.0.2",
           "resolved": false,
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6212,6 +6233,7 @@
           "version": "3.0.1",
           "resolved": false,
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6255,12 +6277,14 @@
         "wrappy": {
           "version": "1.0.2",
           "resolved": false,
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "resolved": false,
-          "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k="
+          "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
+          "optional": true
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -12440,6 +12440,15 @@
         "workbox-webpack-plugin": "3.6.3"
       }
     },
+    "react-tabs": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/react-tabs/-/react-tabs-3.0.0.tgz",
+      "integrity": "sha512-z90cDIb+5V7MzjXFHq1VLxYiMH7dDQWan7mXSw6BWQtw+9pYAnq/fEDvsPaXNyevYitvLetdW87C61uu27JVMA==",
+      "requires": {
+        "classnames": "^2.2.0",
+        "prop-types": "^15.5.0"
+      }
+    },
     "react-virtualized-auto-sizer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "react-mapbox-gl": "^4.1.0",
     "react-router-dom": "^4.3.1",
     "react-scripts": "2.1.3",
+    "react-tabs": "^3.0.0",
     "styled-components": "^4.1.3"
   },
   "scripts": {

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -9,6 +9,7 @@ import { Splash } from "./Splash";
 import { FAQ } from "./FAQ";
 import CurrentConditions from "./CurrentConditions";
 import Kiosks from "./Kiosks";
+import ReturnOfResults from './ReturnOfResults';
 
 class App extends Component {
   render() {
@@ -22,6 +23,7 @@ class App extends Component {
                 <Route exact path="/" component={Splash}/>
                 <Route path="/current" component={CurrentConditions}/>
                 <Route path="/faq" component={FAQ}/>
+                <Route path="/results" component={ReturnOfResults}/>
                 <Route path="/kiosks" component={Kiosks}/>
                 <Footer/>
             </>

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -11,6 +11,7 @@ import CurrentConditions from "./CurrentConditions";
 import Kiosks from "./Kiosks";
 import ReturnOfResults from './ReturnOfResults';
 import FindBarcode from './FindBarcode';
+import ResultsFAQ from './ResultsFAQ';
 
 class App extends Component {
   render() {
@@ -27,6 +28,7 @@ class App extends Component {
                 <Route path="/results" component={ReturnOfResults}/>
                 <Route path="/kiosks" component={Kiosks}/>
                 <Route path="/find-barcode" component={FindBarcode}/>
+                <Route path="/results-faq" component={ResultsFAQ}/>
                 <Footer/>
             </>
           </ThemeProvider>

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -12,6 +12,7 @@ import Kiosks from "./Kiosks";
 import ReturnOfResults from './ReturnOfResults';
 import FindBarcode from './FindBarcode';
 import ResultsFAQ from './ResultsFAQ';
+import FluSequence from './FluSequence';
 
 class App extends Component {
   render() {
@@ -29,6 +30,7 @@ class App extends Component {
                 <Route path="/kiosks" component={Kiosks}/>
                 <Route path="/find-barcode" component={FindBarcode}/>
                 <Route path="/results-faq" component={ResultsFAQ}/>
+                <Route path="/flu/:barcode?" component={FluSequence}/>
                 <Footer/>
             </>
           </ThemeProvider>

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -10,6 +10,7 @@ import { FAQ } from "./FAQ";
 import CurrentConditions from "./CurrentConditions";
 import Kiosks from "./Kiosks";
 import ReturnOfResults from './ReturnOfResults';
+import FindBarcode from './FindBarcode';
 
 class App extends Component {
   render() {
@@ -25,6 +26,7 @@ class App extends Component {
                 <Route path="/faq" component={FAQ}/>
                 <Route path="/results" component={ReturnOfResults}/>
                 <Route path="/kiosks" component={Kiosks}/>
+                <Route path="/find-barcode" component={FindBarcode}/>
                 <Footer/>
             </>
           </ThemeProvider>

--- a/src/components/FindBarcode.js
+++ b/src/components/FindBarcode.js
@@ -1,0 +1,25 @@
+import React from 'react';
+
+import { OuterContainer, ContentContainer, H1, Ordered } from './utils';
+
+const findBarcodeQuestions = [
+    [
+        "What is my barcode?",
+        "Each sample is assigned a unique 8 digit barcode consisting of letters and numbers"
+    ],
+    [
+        "Where do I find my barcode?",
+        "Are participants given a card with their barcode? Do they have to locate their barcode based on study arm?"
+    ]
+]
+
+export default function FindBarcode(props) {
+    return (
+        <OuterContainer>
+            <ContentContainer>
+                <H1>Find My Barcode</H1>
+                <Ordered items={findBarcodeQuestions}/>
+            </ContentContainer>
+        </OuterContainer>
+    )
+}

--- a/src/components/FluSequence.js
+++ b/src/components/FluSequence.js
@@ -1,0 +1,70 @@
+import React from 'react';
+
+import { OuterContainer, ContentContainer, H1, Ordered, Feature, CenteredParagraph } from './utils';
+
+const sequenceFaq = [
+    [
+        "Sequencing is..."
+    ],
+    [
+        "What does that mean?",
+        "Explanation here."
+    ],
+    [
+        "Why do we sequence?",
+        "Explanation here."
+    ]
+]
+
+export default class FluSequence extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            barcode: '',
+            sequenced: false
+        };
+    }
+
+    componentDidMount() {
+        // If this page is reached via an internal link,
+        // then set the state based on information passed
+        if(this.props.location.state){
+            const { barcode, sequenced } = this.props.location.state;
+            this.setState({
+                barcode: barcode,
+                sequenced:sequenced
+            }, () => {
+                console.log(this.state)
+            })
+        }
+    }
+
+    render() {
+        let phylogeny;
+        if(this.state.sequenced && this.state.barcode){
+            phylogeny = (
+                <Feature title="Placeholder for personalized simplified phylogeny">
+                    <CenteredParagraph>Highlight node in phylogeny based on barcode state: {this.state.barcode}</CenteredParagraph>
+                </Feature>
+            );
+        }
+        else{
+            phylogeny = (
+                <Feature title="Placeholder for generic phylogeny">
+                    <CenteredParagraph>
+                        If someone reached this webpage without entering barcode, do we want to display a general phylogeny tree?
+                    </CenteredParagraph>
+                </Feature>
+            )
+        }
+        return(
+            <OuterContainer>
+                <ContentContainer>
+                    <H1>Learn More About Your Flu</H1>
+                    <Ordered items={sequenceFaq}/>
+                    {phylogeny}
+                </ContentContainer>
+            </OuterContainer>
+        )
+    }
+}

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -73,6 +73,7 @@ export default class Header extends React.Component {
         <Spacer/>
         <HeaderLink to="/current">Current Conditions</HeaderLink>
         <HeaderLink to="/kiosks">Find a Kiosk</HeaderLink>
+        <HeaderLink to="/results">Find My Results</HeaderLink>
         <HeaderLink to="/faq">FAQ</HeaderLink>
       </HeaderContainer>
     )

--- a/src/components/ParticipantResults/BarcodeSearchForm.js
+++ b/src/components/ParticipantResults/BarcodeSearchForm.js
@@ -2,6 +2,14 @@ import React from 'react';
 import styled from 'styled-components';
 
 import { Feature } from '../utils';
+import { notReceived,
+         processing,
+         completeNegative,
+         completePositiveFlu,
+         completePositiveMultiple,
+         completeSequenced,
+         wrongBarcode } from './mock-data.js';
+
 
 const Form = styled.form`
     display: flex;
@@ -48,6 +56,29 @@ export default class BarcodeSearchForm extends React.Component {
     handleSubmit = (event) => {
         event.preventDefault();
         // TODO: Make GET request to ID3C with barcode
+        switch(this.state.value) {
+            case "none":
+                this.props.submitResult(notReceived);
+                break;
+            case "processing":
+                this.props.submitResult(processing);
+                break;
+            case "negative":
+                this.props.submitResult(completeNegative);
+                break;
+            case "flu":
+                this.props.submitResult(completePositiveFlu);
+                break;
+            case "multiple":
+                this.props.submitResult(completePositiveMultiple);
+                break;
+            case "sequenced":
+                this.props.submitResult(completeSequenced);
+                break;
+            default:
+                this.props.submitResult(wrongBarcode);
+        }
+
     }
 
     render() {

--- a/src/components/ParticipantResults/BarcodeSearchForm.js
+++ b/src/components/ParticipantResults/BarcodeSearchForm.js
@@ -83,7 +83,9 @@ export default class BarcodeSearchForm extends React.Component {
 
     render() {
         return (
-            <Feature title = "Please input your barcode">
+            <Feature title = "Please input your barcode"
+                buttonLink="/find-barcode"
+                buttonText="Where do I find my barcode?">
                 <Form onSubmit={this.handleSubmit}>
                     <Input required type="text" value={this.state.value} onChange={this.handleChange} />
                     <SubmitButton type="submit">Submit</SubmitButton>

--- a/src/components/ParticipantResults/BarcodeSearchForm.js
+++ b/src/components/ParticipantResults/BarcodeSearchForm.js
@@ -1,0 +1,63 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import { Feature } from '../utils';
+
+const Form = styled.form`
+    display: flex;
+    padding: 20px;
+    justify-content: center;
+`
+const Input = styled.input`
+    width: 80%;
+    padding: 10px;
+    font-size: 1.2em;
+    &:focus {
+        outline: none;
+        border: 2px solid ${props => props.theme.accent500}
+    }
+`
+const SubmitButton = styled.button`
+    width: 20%;
+    border: 1px solid ${props => props.theme.neutral100};
+    background-color: inherit;
+    color: ${props => props.theme.neutral100};
+    border-radius: 3px;
+    padding: 5px;
+    margin: 0px 15px;
+    font-size: 1em;
+    font-weight: 600;
+    text-transform: uppercase;
+    cursor: pointer;
+    &:hover {
+        background-color: ${props => props.theme.primary300};
+        color: ${props => props.theme.white};
+    }
+`
+
+export default class BarcodeSearchForm extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = { value: '' };
+    }
+
+    handleChange = (event) => {
+        this.setState({ value: event.target.value });
+    }
+
+    handleSubmit = (event) => {
+        event.preventDefault();
+        // TODO: Make GET request to ID3C with barcode
+    }
+
+    render() {
+        return (
+            <Feature title = "Please input your barcode">
+                <Form onSubmit={this.handleSubmit}>
+                    <Input required type="text" value={this.state.value} onChange={this.handleChange} />
+                    <SubmitButton type="submit">Submit</SubmitButton>
+                </Form>
+            </Feature>
+        )
+    }
+}

--- a/src/components/ParticipantResults/NegativeResult.js
+++ b/src/components/ParticipantResults/NegativeResult.js
@@ -1,0 +1,46 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import { H3, CenteredParagraph, Feature, UnorderedList } from '../utils';
+
+const P = styled(CenteredParagraph)`
+    font-size: 20px;
+    @media (max-width: 735px) {
+        max-width: 90%;
+    }
+`
+const avoidFlu = [
+    "Get your flu shot every year",
+    "Wash your hands often",
+    "Keep your hands off your face",
+    "Avoid close contact with sick people",
+    "Clean and disinfect surfaces"
+]
+
+export default function NegativeResult(props) {
+    const howToAvoidFlu = avoidFlu.map((tip) =>
+        <li>{tip}</li>
+    );
+
+    return (
+        <div>
+            <H3>Your research test is <b>NEGATIVE</b>.</H3>
+            <P>
+                There are lots of viruses that can cause symptoms,
+                and we don’t have a test that will detect all of them.
+                No test is perfect, and there is a small chance that you
+                do have the flu or another respiratory virus, even with
+                a negative test. Regardless of your test result,
+                it’s best to stay home when you feel sick, and avoid contact
+                with other people. If you have other health problems or are
+                very sick or are worried about your illness, you should contact
+                your health care provider.
+            </P>
+            <Feature title="How to help avoid getting the flu:">
+                <UnorderedList>
+                    {howToAvoidFlu}
+                </UnorderedList>
+            </Feature>
+        </div>
+    )
+}

--- a/src/components/ParticipantResults/NegativeResult.js
+++ b/src/components/ParticipantResults/NegativeResult.js
@@ -2,6 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 
 import { H3, CenteredParagraph, Feature, UnorderedList } from '../utils';
+import { ResultsMoreInfo } from './ResultsMoreInfo';
 
 const P = styled(CenteredParagraph)`
     font-size: 20px;
@@ -41,6 +42,7 @@ export default function NegativeResult(props) {
                     {howToAvoidFlu}
                 </UnorderedList>
             </Feature>
+            <ResultsMoreInfo pathogen="flu"/>
         </div>
     )
 }

--- a/src/components/ParticipantResults/PositiveResult.js
+++ b/src/components/ParticipantResults/PositiveResult.js
@@ -5,13 +5,6 @@ import styled from 'styled-components';
 import { H3 } from '../utils';
 import * as positiveResults from './PositiveResults';
 
-const resultsMap = {
-    "flu": <positiveResults.Flu/>,
-    "rsv": <positiveResults.RSV/>,
-    "coronavirus": <positiveResults.Coronavirus/>,
-    "enterovirus": <positiveResults.Enterovirus/>
-}
-
 const STabs = styled(Tabs)`
     width: 100%;
 `
@@ -59,6 +52,13 @@ const STabPanel = styled(TabPanel)`
 STabPanel.tabsRole = 'TabPanel';
 
 export default function PositiveResult(props) {
+    const resultsMap = {
+        "flu": <positiveResults.Flu sequenced={props.sequenced} barcode={props.barcode}/>,
+        "rsv": <positiveResults.RSV/>,
+        "coronavirus": <positiveResults.Coronavirus/>,
+        "enterovirus": <positiveResults.Enterovirus/>
+    };
+
     const results = props.results.filter(result => resultsMap[result]);
 
     const resultTabs = results.map((result) =>

--- a/src/components/ParticipantResults/PositiveResult.js
+++ b/src/components/ParticipantResults/PositiveResult.js
@@ -1,0 +1,89 @@
+import React from 'react';
+import { Tab, Tabs, TabList, TabPanel } from 'react-tabs';
+import styled from 'styled-components';
+
+import { H3 } from '../utils';
+import * as positiveResults from './PositiveResults';
+
+const resultsMap = {
+    "flu": <positiveResults.Flu/>,
+    "rsv": <positiveResults.RSV/>,
+    "coronavirus": <positiveResults.Coronavirus/>,
+    "enterovirus": <positiveResults.Enterovirus/>
+}
+
+const STabs = styled(Tabs)`
+    width: 100%;
+`
+const STabList = styled(TabList)`
+  list-style-type: none;
+  padding: .25em;
+  display: flex;
+  justify-content: center;
+  margin: 0;
+`
+STabList.tabsRole = 'TabList';
+
+const STab = styled(Tab)`
+  border: 1px solid transparent;
+  border-bottom: none;
+  border-radius: 4px 4px 0px 0px;
+  padding: 1em;
+  user-select: none;
+  cursor: pointer;
+  font-size: 20px;
+  font-weight: 800;
+  text-transform: uppercase;
+
+  &.is-selected {
+    border-color: ${props => props.theme.primary300};
+    border-bottom: 1px solid white;
+  }
+  @media (max-width: 735px) {
+      padding: 0.5em;
+  }
+`
+STab.tabsRole = 'Tab';
+
+const STabPanel = styled(TabPanel)`
+  display: none;
+  min-height: 40vh;
+  border-top: 1px solid ${props => props.theme.primary300};
+  padding: 2em .5em;
+  margin-top: -5px;
+
+  &.is-selected {
+    display: block;
+  }
+`;
+STabPanel.tabsRole = 'TabPanel';
+
+export default function PositiveResult(props) {
+    const results = props.results.filter(result => resultsMap[result]);
+
+    const resultTabs = results.map((result) =>
+        <STab key={result}>{result}</STab>
+    );
+
+    const resultPanels = results.map((result) =>
+        <STabPanel key={result}>
+            {resultsMap[result]}
+        </STabPanel>
+    );
+
+    return (
+        <div>
+            <H3>
+                Your research test is positive for: <br/>
+            </H3>
+            <STabs
+                selectedTabClassName='is-selected'
+                selectedTabPanelClassName='is-selected'>
+                <STabList>
+                    {resultTabs}
+                </STabList>
+                {resultPanels}
+            </STabs>
+        </div>
+    )
+}

--- a/src/components/ParticipantResults/PositiveResults/Coronavirus.js
+++ b/src/components/ParticipantResults/PositiveResults/Coronavirus.js
@@ -1,0 +1,66 @@
+import React from 'react';
+
+import { LargerParagraph, CenteredParagraph, Feature, UnorderedList, Bold } from '../../utils';
+
+const contactHealthCare = [
+    "You are older (>65) and experiencing severe symptoms",
+    "You are immunocompromised",
+    "You have chronic lung disease or other serious, chronic health problems",
+    "You are very sick or are worried about your illness"
+];
+
+const preventCoronavirus = [
+    "Wash your hands often",
+    "Keep your hands off your face",
+    "Avoid close contact with sick people",
+    "Cover your coughs and sneezes",
+    "Clean and disinfect surfaces",
+    "Stay home when you are sick"
+];
+
+export default function Coronavirus(props) {
+
+    const contactHealthCareDisplay = contactHealthCare.map((reason, index) =>
+        <li key={index}>{reason}</li>
+    );
+
+    const preventCoronavirusDisplay = preventCoronavirus.map((tip, index) =>
+        <li key={index}>{tip}</li>
+    );
+
+    return(
+        <div>
+            <LargerParagraph>
+                Your research test is positive for <Bold>Coronavirus</Bold><sup>*</sup>, a type of
+                virus that causes respiratory infections that can be spread from person to person.
+                This infection is usually mild, like the common cold, or moderate, with flu-like
+                symptoms. Symptoms can include fever, runny nose, congestion, cough, and sore throat.
+            </LargerParagraph>
+            <LargerParagraph>
+                Most people with Coronavirus infections do not need medical care, and recover in a
+                week or two. In most cases, it’s best to stay home and avoid contact with other people.
+            </LargerParagraph>
+            <Feature title="Contact your health care provider if:">
+                <UnorderedList>
+                    {contactHealthCareDisplay}
+                </UnorderedList>
+            </Feature>
+            <LargerParagraph>
+                Certain people are at higher risk for severe Coronavirus infections, including
+                older adults, people with chronic lung disease, and immunocompromised individuals.
+                In these groups of people, Coronaviruses can cause pneumonia and exacerbations of
+                asthma or chronic bronchitis.
+            </LargerParagraph>
+            <Feature title="How to help prevent the spread of coronavirus:">
+                <div >
+                <UnorderedList>
+                    {preventCoronavirusDisplay}
+                </UnorderedList>
+                </div>
+            </Feature>
+            <CenteredParagraph>
+                *This research test detects human coronavirus only, and not MERS or SARS coronaviruses.
+            </CenteredParagraph>
+        </div>
+    )
+}

--- a/src/components/ParticipantResults/PositiveResults/Coronavirus.js
+++ b/src/components/ParticipantResults/PositiveResults/Coronavirus.js
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { LargerParagraph, CenteredParagraph, Feature, UnorderedList, Bold } from '../../utils';
+import { ResultsMoreInfo } from '../ResultsMoreInfo';
 
 const contactHealthCare = [
     "You are older (>65) and experiencing severe symptoms",
@@ -61,6 +62,7 @@ export default function Coronavirus(props) {
             <CenteredParagraph>
                 *This research test detects human coronavirus only, and not MERS or SARS coronaviruses.
             </CenteredParagraph>
+            <ResultsMoreInfo pathogen="coronavirus" />
         </div>
     )
 }

--- a/src/components/ParticipantResults/PositiveResults/Enterovirus.js
+++ b/src/components/ParticipantResults/PositiveResults/Enterovirus.js
@@ -1,0 +1,54 @@
+import React from 'react';
+
+import { LargerParagraph, Feature, UnorderedList, Bold } from '../../utils';
+
+const contactHealthCare = [
+    "You are older (>65) and experiencing severe symptoms",
+    "You are immunocompromised",
+    "You have chronic lung disease or other serious, chronic health problems",
+    "You are very sick or are worried about your illness"
+];
+
+const preventEnterovirus = [
+    "Enterovirus can be found in the saliva, mucus and feces (stool) of an infected person",
+    "Wash your hands often with soap and water, especially after sneezing, coughing, going to the bathroom, or changing the diaper of an infected child",
+    "Avoid close contact with other people while you are sick",
+    "Clean and disinfect surfaces"
+]
+
+export default function Enterovirus(props) {
+
+    const contactHealthCareDisplay = contactHealthCare.map((reason, index) =>
+        <li key={index}>{reason}</li>
+    );
+
+    const preventEnterovirusDisplay = preventEnterovirus.map((tip, index) =>
+        <li key={index}>{tip}</li>
+    )
+
+    return(
+        <div>
+            <LargerParagraph left>
+                Your research test is positive for <Bold>Enterovirus</Bold>, a virus that
+                mostly causes mild symptoms, including fever, runny nose, sneezing,
+                cough, and body and muscle aches. Some people may have a skin rash
+                or mouth blisters.
+            </LargerParagraph>
+            <LargerParagraph left>
+                Most people with enterovirus infections do not need medical care,
+                and recover in a week or two. In most cases, it’s best to stay home
+                and avoid contact with other people.
+            </LargerParagraph>
+            <Feature title="Contact your health care provider if:">
+                <UnorderedList>
+                    {contactHealthCareDisplay}
+                </UnorderedList>
+            </Feature>
+            <Feature title="How to prevent the spread of enterovirus:">
+                <UnorderedList>
+                    {preventEnterovirusDisplay}
+                </UnorderedList>
+            </Feature>
+        </div>
+    )
+}

--- a/src/components/ParticipantResults/PositiveResults/Enterovirus.js
+++ b/src/components/ParticipantResults/PositiveResults/Enterovirus.js
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { LargerParagraph, Feature, UnorderedList, Bold } from '../../utils';
+import { ResultsMoreInfo } from '../ResultsMoreInfo';
 
 const contactHealthCare = [
     "You are older (>65) and experiencing severe symptoms",
@@ -49,6 +50,7 @@ export default function Enterovirus(props) {
                     {preventEnterovirusDisplay}
                 </UnorderedList>
             </Feature>
+            <ResultsMoreInfo pathogen="non-polio-enterovirus" />
         </div>
     )
 }

--- a/src/components/ParticipantResults/PositiveResults/Flu.js
+++ b/src/components/ParticipantResults/PositiveResults/Flu.js
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { Bold, LargerParagraph, EvenTwoColumnFeature } from '../../utils';
+import { ResultsMoreInfo } from '../ResultsMoreInfo';
 
 const highRiskConditions = [
     "Asthma or chronic lung disease",
@@ -73,6 +74,8 @@ export default function Flu(props) {
                 medical problems, antivirals may need to be started even if it has been longer than
                 2 days after symptoms began.
             </LargerParagraph>
+            <br/>
+            <ResultsMoreInfo pathogen="flu" />
         </div>
     )
 }

--- a/src/components/ParticipantResults/PositiveResults/Flu.js
+++ b/src/components/ParticipantResults/PositiveResults/Flu.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Bold, LargerParagraph, EvenTwoColumnFeature } from '../../utils';
+import { Bold, LargerParagraph, EvenTwoColumnFeature, InternalLink } from '../../utils';
 import { ResultsMoreInfo } from '../ResultsMoreInfo';
 
 const highRiskConditions = [
@@ -25,6 +25,8 @@ const highRiskGroups = [
     "People who live in nursing homes or long-term care facilities"
 ]
 
+
+
 export default function Flu(props) {
 
     const highRiskConditionsDisplay = highRiskConditions.map((risk, index) =>
@@ -35,11 +37,23 @@ export default function Flu(props) {
         <li key={index}>{risk}</li>
     );
 
+    const fluSequenceLink = (
+        <InternalLink to={{
+            pathname: `/flu`,
+            state: {
+                barcode: props.barcode,
+                sequenced: props.sequenced
+            }}}>
+            here
+        </InternalLink>
+    );
+
     return(
         <div>
             <LargerParagraph>
                 Your research test is positive for <Bold>influenza (flu)</Bold>,
                 a virus that causes a respiratory infection that can be spread from person to person.
+                (Learn more about <i>your</i> flu {fluSequenceLink})
             </LargerParagraph>
             <LargerParagraph>
                 Most people with the flu do not need medical care or antiviral drugs.

--- a/src/components/ParticipantResults/PositiveResults/Flu.js
+++ b/src/components/ParticipantResults/PositiveResults/Flu.js
@@ -1,0 +1,78 @@
+import React from 'react';
+
+import { Bold, LargerParagraph, EvenTwoColumnFeature } from '../../utils';
+
+const highRiskConditions = [
+    "Asthma or chronic lung disease",
+    "Heart disease or stroke",
+    "Diabetes",
+    "HIV/AIDS",
+    "Cancer",
+    "Taking medicines that suppress the immune system",
+    "Liver or kidney disease",
+    "Neurologic or developmental conditions",
+    "Blood disorders such as sickle cell",
+    "Severe obesity (not just overweight)",
+    "People under 19 on long-term aspirin"
+];
+
+const highRiskGroups = [
+    "Pregnant women, up to 2 weeks after delivery",
+    "Adults 65 years of age or older",
+    "Children younger than 2 years",
+    "American Indians and Alaska Natives",
+    "People who live in nursing homes or long-term care facilities"
+]
+
+export default function Flu(props) {
+
+    const highRiskConditionsDisplay = highRiskConditions.map((risk, index) =>
+        <li key={index}>{risk}</li>
+    );
+
+    const highRiskGroupsDisplay = highRiskGroups.map((risk, index) =>
+        <li key={index}>{risk}</li>
+    );
+
+    return(
+        <div>
+            <LargerParagraph>
+                Your research test is positive for <Bold>influenza (flu)</Bold>,
+                a virus that causes a respiratory infection that can be spread from person to person.
+            </LargerParagraph>
+            <LargerParagraph>
+                Most people with the flu do not need medical care or antiviral drugs.
+                In most cases, it’s best to stay home and avoid contact with other
+                people. If you have other health problems or are very sick or are
+                worried about your illness, you should contact your health care provider.
+            </LargerParagraph>
+            <LargerParagraph>
+                Some people are at high risk for serious flu-related complications,
+                such as needing to go to the hospital or having trouble breathing because
+                of pneumonia.
+            </LargerParagraph>
+            <EvenTwoColumnFeature title="People at high risk of severe flu include:">
+                <div>
+                    <h3>People with the following conditions:</h3>
+                    <ul>
+                        {highRiskConditionsDisplay}
+                    </ul>
+                </div>
+                <div>
+                    <h3>People in the following groups:</h3>
+                    <ul>
+                        {highRiskGroupsDisplay}
+                    </ul>
+                </div>
+            </EvenTwoColumnFeature>
+            <LargerParagraph>
+                <b>If you are in one of these high-risk groups, please contact your provider today </b>
+                 to discuss your symptoms and discuss if you need to be examined.  You should also
+                discuss whether you would benefit from antiviral medicines.  Antiviral medicines
+                help the most when started within 2 days after symptoms begin. For people with other
+                medical problems, antivirals may need to be started even if it has been longer than
+                2 days after symptoms began.
+            </LargerParagraph>
+        </div>
+    )
+}

--- a/src/components/ParticipantResults/PositiveResults/RSV.js
+++ b/src/components/ParticipantResults/PositiveResults/RSV.js
@@ -1,0 +1,73 @@
+import React from 'react';
+
+import { LargerParagraph, Bold, EvenTwoColumnFeature, Feature, UnorderedList } from '../../utils';
+
+const preventRSV = [
+    "Wash your hands often",
+    "Keep your hands off your face",
+    "Avoid close contact with sick people",
+    "Cover your coughs and sneezes",
+    "Clean and disinfect surfaces",
+    "Stay home when you are sick"
+];
+
+const highRiskAdult = [
+    "Older adults, especially those 65 years and older",
+    "Adults with chronic heart or lung disease",
+    "Adults with weakened immune systems"
+];
+
+const highRiskChildren = [
+    "Premature infants",
+    "Very young infants, especially those 6 months and younger",
+    "Children younger than 2 years old with chronic lung or heart disease",
+    "Children with weakened immune systems",
+    "Children who have neuromuscular disorders, including those who have difficulty swallowing or clearing mucus secretions"
+]
+
+export default function RSV(props) {
+
+    const preventRSVDisplay = preventRSV.map((tip, index) =>
+        <li key={index}>{tip}</li>
+    );
+
+    const highRiskAdultDisplay = highRiskAdult.map((risk, index) =>
+        <li key={index}>{risk}</li>
+    );
+
+    const highRiskChildrenDisplay = highRiskChildren.map((risk, index) =>
+        <li key={index}>{risk}</li>
+    );
+
+    return(
+        <div>
+            <LargerParagraph>
+                Your research test is positive for <Bold>Respiratory Syncytial Virus Infection (RSV)</Bold>,
+                a virus that causes a respiratory infection that can be spread from person to person.
+                This infection is usually  mild in adults, like the common cold.
+            </LargerParagraph>
+            <LargerParagraph>
+                Most people with RSV do not need medical care and get better in a week or two.
+                In most cases, it’s best to stay home while you are sick, and avoid contact with
+                other people.
+            </LargerParagraph>
+            <Feature title="How to prevent the spread of RSV">
+                <UnorderedList>
+                    {preventRSVDisplay}
+                </UnorderedList>
+            </Feature>
+            <LargerParagraph>
+                If you are at high risk for severe RSV or are very sick or are worried about your
+                illness, you should contact your health care provider.
+            </LargerParagraph>
+            <EvenTwoColumnFeature title="People at high risk for severe RSV include:">
+                <ul>
+                    {highRiskAdultDisplay}
+                </ul>
+                <ul>
+                    {highRiskChildrenDisplay}
+                </ul>
+            </EvenTwoColumnFeature>
+        </div>
+    )
+}

--- a/src/components/ParticipantResults/PositiveResults/RSV.js
+++ b/src/components/ParticipantResults/PositiveResults/RSV.js
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { LargerParagraph, Bold, EvenTwoColumnFeature, Feature, UnorderedList } from '../../utils';
+import { ResultsMoreInfo } from '../ResultsMoreInfo';
 
 const preventRSV = [
     "Wash your hands often",
@@ -68,6 +69,7 @@ export default function RSV(props) {
                     {highRiskChildrenDisplay}
                 </ul>
             </EvenTwoColumnFeature>
+            <ResultsMoreInfo pathogen="rsv"/>
         </div>
     )
 }

--- a/src/components/ParticipantResults/PositiveResults/index.js
+++ b/src/components/ParticipantResults/PositiveResults/index.js
@@ -1,0 +1,4 @@
+export {default as Flu} from './Flu';
+export {default as RSV} from './RSV';
+export {default as Coronavirus} from './Coronavirus';
+export {default as Enterovirus} from './Enterovirus';

--- a/src/components/ParticipantResults/Results.js
+++ b/src/components/ParticipantResults/Results.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import { Feature, H3 } from '../utils';
+import NegativeResult from './NegativeResult';
+
+const P = styled(H3)`
+    color: inherit;
+`
+const MoreInfo = styled.p`
+    margin: 1em;
+    padding-bottom: 1.5em;
+    font-size: 16px;
+    text-align: center;
+`
+export default function Results(props) {
+    const results = props.results;
+    let display;
+    if(results.length === 0) {
+        display = <NegativeResult />
+    }
+    return (
+        <div>
+            <Feature>
+                <P>
+                    This is a research test and should not be used as a substitute for a
+                    visit to your health care provider.
+                </P>
+            </Feature>
+            {display}
+            <MoreInfo>
+                <b>If your health care provider wants to know more</b> about these
+                test results, please contact us at (WEBSITE OR PHONE NUMBER).
+                <br/>
+                For more information, please visit the US Center for Disease Control
+                at <a href="https://www.cdc.gov/flu">www.cdc.gov/flu</a>
+            </MoreInfo>
+        </div>
+    )
+
+}

--- a/src/components/ParticipantResults/Results.js
+++ b/src/components/ParticipantResults/Results.js
@@ -15,7 +15,7 @@ export default function Results(props) {
         display = <NegativeResult />
     }
     else {
-        display = <PositiveResult results={results} />
+        display = <PositiveResult results={results} sequenced={props.sequenced} barcode={props.barcode}/>
     }
 
     return (

--- a/src/components/ParticipantResults/Results.js
+++ b/src/components/ParticipantResults/Results.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 
-import { Feature, H3, Bold } from '../utils';
+import { Feature, H3, InternalLink } from '../utils';
 import NegativeResult from './NegativeResult';
 import PositiveResult from './PositiveResult';
 
@@ -20,10 +20,10 @@ export default function Results(props) {
 
     return (
         <div>
-            <Feature>
+            <Feature title="This is a research test and should not be used as a substitute for a
+                    visit to your health care provider.">
                 <P>
-                    This is a research test and should not be used as a substitute for a
-                    visit to your health care provider.
+                    Learn more about how the research test works <InternalLink to="/results-faq" target="_blank">here</InternalLink>.
                 </P>
             </Feature>
             {display}

--- a/src/components/ParticipantResults/Results.js
+++ b/src/components/ParticipantResults/Results.js
@@ -1,18 +1,12 @@
 import React from 'react';
 import styled from 'styled-components';
 
-import { Feature, H3 } from '../utils';
+import { Feature, H3, Bold } from '../utils';
 import NegativeResult from './NegativeResult';
 import PositiveResult from './PositiveResult';
 
 const P = styled(H3)`
     color: inherit;
-`
-const MoreInfo = styled.p`
-    margin: 1em;
-    padding-bottom: 1.5em;
-    font-size: 16px;
-    text-align: center;
 `
 export default function Results(props) {
     const results = props.results;
@@ -23,6 +17,7 @@ export default function Results(props) {
     else {
         display = <PositiveResult results={results} />
     }
+
     return (
         <div>
             <Feature>
@@ -32,13 +27,6 @@ export default function Results(props) {
                 </P>
             </Feature>
             {display}
-            <MoreInfo>
-                <b>If your health care provider wants to know more</b> about these
-                test results, please contact us at (WEBSITE OR PHONE NUMBER).
-                <br/>
-                For more information, please visit the US Center for Disease Control
-                at <a href="https://www.cdc.gov/flu">www.cdc.gov/flu</a>
-            </MoreInfo>
         </div>
     )
 

--- a/src/components/ParticipantResults/Results.js
+++ b/src/components/ParticipantResults/Results.js
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 
 import { Feature, H3 } from '../utils';
 import NegativeResult from './NegativeResult';
+import PositiveResult from './PositiveResult';
 
 const P = styled(H3)`
     color: inherit;
@@ -18,6 +19,9 @@ export default function Results(props) {
     let display;
     if(results.length === 0) {
         display = <NegativeResult />
+    }
+    else {
+        display = <PositiveResult results={results} />
     }
     return (
         <div>

--- a/src/components/ParticipantResults/ResultsMoreInfo.js
+++ b/src/components/ParticipantResults/ResultsMoreInfo.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import { Bold, ExternalLink } from '../utils';
+
+export const ResultsMoreInfo = (props) => {
+    const MoreInfo = styled.div`
+      margin: 1em;
+      padding-bottom: 1.5em;
+      font-size: 16px;
+      text-align: center;
+    `
+    return (
+      <MoreInfo>
+            <Bold>If your health care provider wants to know more</Bold> about these
+            test results, please contact us at (WEBSITE OR PHONE NUMBER).
+            <hr/>
+            For more information, please visit the US Center for Disease Control at <ExternalLink href={`http://cdc.gov/${props.pathogen}`} target="_blank">www.cdc.gov/{props.pathogen}</ExternalLink>
+      </MoreInfo>
+    )
+}

--- a/src/components/ParticipantResults/SampleNotReceived.js
+++ b/src/components/ParticipantResults/SampleNotReceived.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import { Feature, H3 } from '../utils';
+
+const P = styled(H3)`
+    color: inherit;
+`
+const Br = styled.br`
+    line-height: 3
+`
+
+export default function SampleNotReceived(props) {
+    return (
+        <Feature title="Thank you for participating in our study!"
+            buttonLink="/current"
+            buttonText="Current Conditions">
+            <P>
+                Your sample has not been received yet. <br/>
+                It takes 24-48 hours to receive samples. <br/>
+                Please check back again.
+                <Br/>
+                In the meantime, checkout out the current flu conditions:
+            </P>
+        </Feature>
+    )
+
+};

--- a/src/components/ParticipantResults/SampleProcessing.js
+++ b/src/components/ParticipantResults/SampleProcessing.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import { Feature, H3 } from '../utils';
+
+const P = styled(H3)`
+    color: inherit;
+`
+const Br = styled.br`
+    line-height: 3;
+`
+
+export default function SampleProcessing(props) {
+    return (
+        <div>
+            <Feature title="Your sample has been received and we are processing it!"
+                buttonLink="/current"
+                buttonText="Current Conditions">
+                <P>
+                    Check back in a few days to see your results!
+                    <Br/>
+                    In the meantime, checkout out the current flu conditions:
+                </P>
+            </Feature>
+            <Feature title='What does "processing" mean?'>
+                <P>
+                    The sample is in the lab and being prepared for presence/absence testing.<br/>
+                    What else do we want to add here?
+                </P>
+            </Feature>
+        </div>
+    )
+}

--- a/src/components/ParticipantResults/UnknownBarcode.js
+++ b/src/components/ParticipantResults/UnknownBarcode.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import { H2, H3 } from '../utils';
+
+const Banner = styled.div`
+    background-color: ${props => props.theme.accent500};
+    padding: 1em;
+`
+
+export default function UnknownBarcode(props) {
+    return (
+        <Banner>
+            <H2>Oops! We don't have that barcode!</H2>
+            <H3>
+                Please double check that you have entered the correct barcode.
+            </H3>
+        </Banner>
+    )
+}

--- a/src/components/ParticipantResults/mock-data.js
+++ b/src/components/ParticipantResults/mock-data.js
@@ -19,19 +19,22 @@ export const completeNegative = {
 export const completePositiveFlu= {
     "barcode": "34567890",
     "status": "complete",
-    "results": ["flu"]
+    "results": ["flu"],
+    "sequenced": false
 };
 
 export const completePositiveMultiple= {
     "barcode": "34567890",
     "status": "complete",
-    "results": ["flu", "rsv", "coronavirus", "enterovirus"]
+    "results": ["flu", "rsv", "coronavirus", "enterovirus"],
+    "sequenced": false
 };
 
 export const completeSequenced = {
     "barcode": "34567890",
-    "status": "completeSequenced",
-    "results": ["flu", "rsv"]
+    "status": "complete",
+    "results": ["flu", "rsv"],
+    "sequenced": true
 }
 
 export const wrongBarcode = {

--- a/src/components/ParticipantResults/mock-data.js
+++ b/src/components/ParticipantResults/mock-data.js
@@ -19,19 +19,19 @@ export const completeNegative = {
 export const completePositiveFlu= {
     "barcode": "34567890",
     "status": "complete",
-    "results": ["Flu"]
+    "results": ["flu"]
 };
 
 export const completePositiveMultiple= {
     "barcode": "34567890",
     "status": "complete",
-    "results": ["Flu", "RSV"]
+    "results": ["flu", "rsv", "coronavirus", "enterovirus"]
 };
 
 export const completeSequenced = {
     "barcode": "34567890",
     "status": "completeSequenced",
-    "results": ["Flu", "RSV"]
+    "results": ["flu", "rsv"]
 }
 
 export const wrongBarcode = {

--- a/src/components/ParticipantResults/mock-data.js
+++ b/src/components/ParticipantResults/mock-data.js
@@ -1,0 +1,41 @@
+export const notReceived = {
+    "barcode": "12345678",
+    "status": "notReceived",
+    "results": []
+};
+
+export const processing = {
+    "barcode": "23456789",
+    "status": "processing",
+    "results": []
+};
+
+export const completeNegative = {
+    "barcode": "34567890",
+    "status": "complete",
+    "results": []
+};
+
+export const completePositiveFlu= {
+    "barcode": "34567890",
+    "status": "complete",
+    "results": ["Flu"]
+};
+
+export const completePositiveMultiple= {
+    "barcode": "34567890",
+    "status": "complete",
+    "results": ["Flu", "RSV"]
+};
+
+export const completeSequenced = {
+    "barcode": "34567890",
+    "status": "completeSequenced",
+    "results": ["Flu", "RSV"]
+}
+
+export const wrongBarcode = {
+    "barcode": null,
+    "status": "unknownBarcode",
+    "results": null
+}

--- a/src/components/ParticipantResults/mock-data.js
+++ b/src/components/ParticipantResults/mock-data.js
@@ -19,21 +19,21 @@ export const completeNegative = {
 export const completePositiveFlu= {
     "barcode": "34567890",
     "status": "complete",
-    "results": ["flu"],
+    "results": ["Influenza.A.H1N1"],
     "sequenced": false
 };
 
 export const completePositiveMultiple= {
     "barcode": "34567890",
     "status": "complete",
-    "results": ["flu", "rsv", "coronavirus", "enterovirus"],
+    "results": ["Influenza.A.H1N1", "RSV.A", "coronavirus", "enterovirus"],
     "sequenced": false
 };
 
 export const completeSequenced = {
     "barcode": "34567890",
     "status": "complete",
-    "results": ["flu", "rsv"],
+    "results": ["Influenza.A.H1N1", "RSV.A"],
     "sequenced": true
 }
 

--- a/src/components/ResultsFAQ.js
+++ b/src/components/ResultsFAQ.js
@@ -1,0 +1,29 @@
+import React from 'react';
+
+import { OuterContainer, ContentContainer, H1, Ordered} from './utils';
+
+const resultsFaq = [
+    [
+        "What do we test for?",
+        "List of pathogens that we test for here."
+    ],
+    [
+        "Why do we test for these?",
+        "Explanation of why we test here."
+    ],
+    [
+        "What does x mean?",
+        "X means ..."
+    ]
+]
+
+export default function ResultsFAQ(props) {
+    return(
+        <OuterContainer>
+            <ContentContainer>
+                <H1>Results FAQ</H1>
+                <Ordered items={resultsFaq}/>
+            </ContentContainer>
+        </OuterContainer>
+    )
+}

--- a/src/components/ReturnOfResults.js
+++ b/src/components/ReturnOfResults.js
@@ -2,6 +2,7 @@ import React from 'react';
 
 import { H1, OuterContainer, ContentContainer } from './utils';
 import BarcodeSearchForm from './ParticipantResults/BarcodeSearchForm';
+import SampleNotReceived from "./ParticipantResults/SampleNotReceived";
 
 export default class ReturnOfResults extends React.Component {
     constructor(props) {
@@ -26,6 +27,9 @@ export default class ReturnOfResults extends React.Component {
                     <H1>Return of Results</H1>
                     { this.state.barcode === '' &&
                         <BarcodeSearchForm submitResult={this.setResult}/>
+                    }
+                    { this.state.status === 'notReceived' &&
+                        <SampleNotReceived/>
                     }
                 </ContentContainer>
             </OuterContainer>

--- a/src/components/ReturnOfResults.js
+++ b/src/components/ReturnOfResults.js
@@ -4,6 +4,7 @@ import { H1, OuterContainer, ContentContainer } from './utils';
 import BarcodeSearchForm from './ParticipantResults/BarcodeSearchForm';
 import SampleNotReceived from './ParticipantResults/SampleNotReceived';
 import SampleProcessing from './ParticipantResults/SampleProcessing';
+import UnknownBarcode from './ParticipantResults/UnknownBarcode';
 
 export default class ReturnOfResults extends React.Component {
     constructor(props) {
@@ -22,19 +23,28 @@ export default class ReturnOfResults extends React.Component {
     }
 
     render(){
+        const sampleStatus = this.state.status;
+        let display;
+
+        switch(sampleStatus) {
+            case 'notReceived':
+                display = <SampleNotReceived/>;
+                break;
+            case 'processing':
+                display = <SampleProcessing />;
+                break;
+            case 'unknownBarcode':
+                display = <div><UnknownBarcode /><BarcodeSearchForm submitResult={this.setResult}/></div>;
+                break;
+            default:
+                display = <BarcodeSearchForm submitResult={this.setResult}/>;
+        }
+
         return (
             <OuterContainer>
                 <ContentContainer>
                     <H1>Return of Results</H1>
-                    { this.state.barcode === '' &&
-                        <BarcodeSearchForm submitResult={this.setResult}/>
-                    }
-                    { this.state.status === 'notReceived' &&
-                        <SampleNotReceived/>
-                    }
-                    { this.state.status === 'processing' &&
-                        <SampleProcessing />
-                    }
+                    {display}
                 </ContentContainer>
             </OuterContainer>
         )

--- a/src/components/ReturnOfResults.js
+++ b/src/components/ReturnOfResults.js
@@ -9,8 +9,7 @@ export default class ReturnOfResults extends React.Component {
         this.state = {
             barcode: '',
             status: '',
-            results: [],
-            sequenced: ''
+            results: []
         };
     }
 

--- a/src/components/ReturnOfResults.js
+++ b/src/components/ReturnOfResults.js
@@ -2,7 +2,8 @@ import React from 'react';
 
 import { H1, OuterContainer, ContentContainer } from './utils';
 import BarcodeSearchForm from './ParticipantResults/BarcodeSearchForm';
-import SampleNotReceived from "./ParticipantResults/SampleNotReceived";
+import SampleNotReceived from './ParticipantResults/SampleNotReceived';
+import SampleProcessing from './ParticipantResults/SampleProcessing';
 
 export default class ReturnOfResults extends React.Component {
     constructor(props) {
@@ -30,6 +31,9 @@ export default class ReturnOfResults extends React.Component {
                     }
                     { this.state.status === 'notReceived' &&
                         <SampleNotReceived/>
+                    }
+                    { this.state.status === 'processing' &&
+                        <SampleProcessing />
                     }
                 </ContentContainer>
             </OuterContainer>

--- a/src/components/ReturnOfResults.js
+++ b/src/components/ReturnOfResults.js
@@ -19,6 +19,17 @@ export default class ReturnOfResults extends React.Component {
     }
 
     setResult = (newResults) => {
+        // Convert ID3C lineages to generic pathogen names used in the rest of the app
+        newResults["results"] = newResults["results"].map(lineage => {
+            if(lineage.includes('Influenza')){
+                    return 'flu'
+            }
+            if(lineage.includes('RSV')){
+                    return 'rsv'
+            }
+            return lineage
+        });
+
         this.setState(newResults, () => {
             console.log(this.state)
         });

--- a/src/components/ReturnOfResults.js
+++ b/src/components/ReturnOfResults.js
@@ -1,19 +1,36 @@
 import React from 'react';
 
-import { H1, OuterContainer, ContentContainer, Feature } from './utils';
+import { H1, OuterContainer, ContentContainer } from './utils';
+import BarcodeSearchForm from './ParticipantResults/BarcodeSearchForm';
 
 export default class ReturnOfResults extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            barcode: '',
+            status: '',
+            results: [],
+            sequenced: ''
+        };
+    }
+
+    setResult = (newResults) => {
+        this.setState(newResults, () => {
+            console.log(this.state)
+        });
+    }
+
     render(){
         return (
             <OuterContainer>
                 <ContentContainer>
                     <H1>Return of Results</H1>
-
-                    <Feature title="Please input your barcode">
-
-                    </Feature>
+                    { this.state.barcode === '' &&
+                        <BarcodeSearchForm submitResult={this.setResult}/>
+                    }
                 </ContentContainer>
             </OuterContainer>
         )
+
     }
 }

--- a/src/components/ReturnOfResults.js
+++ b/src/components/ReturnOfResults.js
@@ -5,6 +5,7 @@ import BarcodeSearchForm from './ParticipantResults/BarcodeSearchForm';
 import SampleNotReceived from './ParticipantResults/SampleNotReceived';
 import SampleProcessing from './ParticipantResults/SampleProcessing';
 import UnknownBarcode from './ParticipantResults/UnknownBarcode';
+import Results from './ParticipantResults/Results';
 
 export default class ReturnOfResults extends React.Component {
     constructor(props) {
@@ -35,6 +36,9 @@ export default class ReturnOfResults extends React.Component {
                 break;
             case 'unknownBarcode':
                 display = <div><UnknownBarcode /><BarcodeSearchForm submitResult={this.setResult}/></div>;
+                break;
+            case 'complete':
+                display = <Results results={ this.state.results }/>;
                 break;
             default:
                 display = <BarcodeSearchForm submitResult={this.setResult}/>;

--- a/src/components/ReturnOfResults.js
+++ b/src/components/ReturnOfResults.js
@@ -1,0 +1,19 @@
+import React from 'react';
+
+import { H1, OuterContainer, ContentContainer, Feature } from './utils';
+
+export default class ReturnOfResults extends React.Component {
+    render(){
+        return (
+            <OuterContainer>
+                <ContentContainer>
+                    <H1>Return of Results</H1>
+
+                    <Feature title="Please input your barcode">
+
+                    </Feature>
+                </ContentContainer>
+            </OuterContainer>
+        )
+    }
+}

--- a/src/components/ReturnOfResults.js
+++ b/src/components/ReturnOfResults.js
@@ -13,7 +13,8 @@ export default class ReturnOfResults extends React.Component {
         this.state = {
             barcode: '',
             status: '',
-            results: []
+            results: [],
+            sequenced: false
         };
     }
 
@@ -35,10 +36,10 @@ export default class ReturnOfResults extends React.Component {
                 display = <SampleProcessing />;
                 break;
             case 'unknownBarcode':
-                display = <div><UnknownBarcode /><BarcodeSearchForm submitResult={this.setResult}/></div>;
+                display = <div><UnknownBarcode /><BarcodeSearchForm submitResult={ this.setResult }/></div>;
                 break;
             case 'complete':
-                display = <Results results={ this.state.results }/>;
+                display = <Results results={ this.state.results } sequenced={ this.state.sequenced } barcode={ this.state.barcode } />;
                 break;
             default:
                 display = <BarcodeSearchForm submitResult={this.setResult}/>;

--- a/src/components/utils.js
+++ b/src/components/utils.js
@@ -303,3 +303,12 @@ export const Quote = (props) => {
     </QuoteContainer>
   )
 }
+
+export const UnorderedList = styled.ul`
+    margin: auto;
+    width: fit-content;
+    font-size: 20px;
+    @media (max-width: 768px) {
+        width: 75%;
+    }
+`

--- a/src/components/utils.js
+++ b/src/components/utils.js
@@ -39,6 +39,16 @@ export const LeftParagraph = styled.p`
     max-width: 100%;
   }
 `
+export const LargerParagraph = styled.p`
+  font-size: 20px;
+  line-height: 1.5;
+  margin: 1em auto;
+  max-width: 80%;
+  @media (max-width: 735px) {
+    max-width: 95%;
+  }
+`
+
 export const HeroContainer = styled.div`
   display: flex;
   flex-direction: row;
@@ -107,7 +117,7 @@ export const Bold = styled.span`
 `
 
 /* Feature Block */
-const FeatureContainer = styled.div`
+export const FeatureContainer = styled.div`
   color: ${props => props.theme.white};
   background-color: ${props => props.theme.primary500};
   padding: 1em 2em;
@@ -172,6 +182,11 @@ const FeatureSidebar = styled.div`
   }
 `;
 
+const FeatureSection = styled.section`
+    flex: 5;
+    margin-left: 2em;
+`
+
 export const Feature = (props) => {
   const children = React.Children.toArray(props.children);
   return (
@@ -199,6 +214,23 @@ export const Feature = (props) => {
       ) : null}
     </FeatureContainer>
   );
+}
+
+export const EvenTwoColumnFeature = (props) => {
+  const children = React.Children.toArray(props.children);
+  return (
+    <FeatureContainer>
+        <FeatureTitle>{props.title}</FeatureTitle>
+        <FeatureFlexContainer>
+            <FeatureSection>
+                {children[0]}
+            </FeatureSection>
+            <FeatureSection>
+                {children[1]}
+            </FeatureSection>
+        </FeatureFlexContainer>
+    </FeatureContainer>
+  )
 }
 
 


### PR DESCRIPTION
This is a skeleton of the return of results that includes mock data used to generate the pages. 

Input the following into the barcode search box to see the different pages:
* "none" => sample not received
* "processing" => sample processing
* "negative" => negative test result
* "flu" => flu positive result
* "multiple" => positive for multiple pathogens, shows all prose we have from Chu lab
* "sequenced" => flu positive with phylogeny placeholder (the results page looks exactly the same as the flu positive page, only difference is phylogeny page after clicking `Learn more about your flu here`)

Any other inputs will default to the wrong barcode display. 

---

- [x] Remove stray curly brace/bracket in b0f5905f on the results page
- [x] Rename `/findbarcode` → `/find-barcode` _or_ incorporate the content inline in `/results`. 
- [x] Rename `/resultsfaq` → `/results/faq` or `/faq/results` or `/results-faq`.
- [x] Replace "irregardless" with "regardless"
- [x] Commit `907f4ea...  Add barcode search form to return of results` requires `mock-data.js` but doesn't import it until the next commit.
- [x] You may want to edit the commit messages for a few of these that still have squashed commit messages in them
- [x] Switch pathogen names to our lineages so we have to do less data munging later