### PR TITLE
Season timeline

### DIFF
--- a/current/src/components/CurrentConditions.js
+++ b/current/src/components/CurrentConditions.js
@@ -12,7 +12,7 @@ import fluStats from '../data/flu-by-week.json';
 
 export default class CurrentConditions extends React.Component {
   state = {
-    currentDate: DateTime.local(),
+    displayDate: DateTime.local(),
     store: immutable({
       dataSource: null
     })
@@ -23,7 +23,7 @@ export default class CurrentConditions extends React.Component {
     const week = location.searchParams.get("week");
 
     if (week)
-      this.setState(s => ({...s, currentDate: DateTime.fromISO(week)}));
+      this.setState(s => ({...s, displayDate: DateTime.fromISO(week)}));
 
     try {
       const geojson = await dataSource();
@@ -37,11 +37,15 @@ export default class CurrentConditions extends React.Component {
     }
   }
 
+  updateCurrentDate = (newDate) => {
+    this.setState({ displayDate: newDate });
+  }
+
   render() {
     const thisWeek = DateTime.local().toFormat("kkkk-'W'WW");
 
-    const currentDate = this.state.currentDate;
-    const currentWeek = currentDate.toFormat("kkkk-'W'WW");
+    const { displayDate } = this.state;
+    const currentWeek = displayDate.toFormat("kkkk-'W'WW");
 
     //const fluCurrentStatusText = generateCurrentStatusText(fluStats);
 
@@ -51,7 +55,7 @@ export default class CurrentConditions extends React.Component {
           <i>During flu season, everyone should take precautions to prevent the spread of flu. To learn more, visit the Seattle Flu Study <a href="/resources">resources page</a>.</i>
         </p>
 
-        <SeasonTimeline dataSource={this.state.store.get("dataSource")} date={currentDate} />
+        <SeasonTimeline dataSource={this.state.store.get("dataSource")} date={displayDate} updateCurrentDate={this.updateCurrentDate}/>
 
         <p>
           The map below shows an estimate for flu circulation for
@@ -64,7 +68,7 @@ export default class CurrentConditions extends React.Component {
         </p>
 
         <ColorRamp />
-        <FluMap dataSource={this.state.store.get("dataSource")} date={currentDate} />
+        <FluMap dataSource={this.state.store.get("dataSource")} date={displayDate} />
 
         <p />
 

--- a/current/src/components/CurrentConditions.js
+++ b/current/src/components/CurrentConditions.js
@@ -1,25 +1,40 @@
 import React from 'react';
 import { DateTime } from 'luxon';
+import { fromJS as immutable } from 'immutable';
 
 import FluMap from './FluMap/';
 import { ColorRamp } from './FluMap/styles';
+import { dataSource } from './FluMap/data';
 import SeasonTimeline from './SeasonTimeline';
 import fluStats from '../data/flu-by-week.json';
 
-const SEASON_CUTOFF_MONTH = 9;
-const FLU_SEASON_START_DATE = DateTime.local(2019, 11, 18);
+
 
 export default class CurrentConditions extends React.Component {
   state = {
     currentDate: DateTime.local(),
+    store: immutable({
+      dataSource: null
+    })
   };
 
-  componentDidMount() {
+  async componentDidMount() {
     const location = new URL(document.location);
     const week = location.searchParams.get("week");
 
     if (week)
       this.setState(s => ({...s, currentDate: DateTime.fromISO(week)}));
+
+    try {
+      const geojson = await dataSource();
+      console.debug("Fetched data source:", geojson.toJS());
+
+      this.setState(state => ({store: state.store.set("dataSource", geojson)}));
+    }
+    catch(err) {
+      console.error(`Unable to load data source:`, err);
+      return;
+    }
   }
 
   render() {
@@ -27,14 +42,6 @@ export default class CurrentConditions extends React.Component {
 
     const currentDate = this.state.currentDate;
     const currentWeek = currentDate.toFormat("kkkk-'W'WW");
-    const currentMonth = currentDate.month;
-    const currentFullMonth = currentDate.monthLong;
-    const currentYear = currentDate.year;
-    const currentDay = currentDate.day;
-    const seasonStartYear = currentMonth < SEASON_CUTOFF_MONTH ? currentYear - 1 : currentYear;
-    const sinceSeasonStart = currentDate.diff(FLU_SEASON_START_DATE, ['months', 'weeks']).toObject();
-    const monthsSinceSeasonStart = sinceSeasonStart.months;
-    const weeksSinceSeasonStart = Math.round(sinceSeasonStart.weeks);
 
     //const fluCurrentStatusText = generateCurrentStatusText(fluStats);
 
@@ -44,20 +51,7 @@ export default class CurrentConditions extends React.Component {
           <i>During flu season, everyone should take precautions to prevent the spread of flu. To learn more, visit the Seattle Flu Study <a href="/resources">resources page</a>.</i>
         </p>
 
-        <p>
-          {thisWeek === currentWeek
-            ? `It’s ${currentFullMonth} ${currentDay}, ${currentYear}, which means we’re `
-            : `On ${currentFullMonth} ${currentDay}, ${currentYear}, we ${currentWeek < thisWeek ? "were" : "will be"} `}
-
-          {monthsSinceSeasonStart > 0 && <strong>{monthsSinceSeasonStart} {monthsSinceSeasonStart > 1 ? "months" : "month"} </strong>}
-          {(monthsSinceSeasonStart > 0 && weeksSinceSeasonStart > 0) && <strong>and </strong>}
-          {weeksSinceSeasonStart > 0 && <strong>{weeksSinceSeasonStart} {weeksSinceSeasonStart > 1 ? "weeks": "week"} </strong>}
-          into the {seasonStartYear}–{seasonStartYear + 1} flu season.
-
-          {/*This week we’re <strong>{fluCurrentStatusText}</strong>.*/}
-        </p>
-
-        <SeasonTimeline date={currentDate} />
+        <SeasonTimeline dataSource={this.state.store.get("dataSource")} date={currentDate} />
 
         <p>
           The map below shows an estimate for flu circulation for
@@ -70,7 +64,7 @@ export default class CurrentConditions extends React.Component {
         </p>
 
         <ColorRamp />
-        <FluMap date={currentDate} />
+        <FluMap dataSource={this.state.store.get("dataSource")} date={currentDate} />
 
         <p />
 

--- a/current/src/components/FluMap/index.js
+++ b/current/src/components/FluMap/index.js
@@ -4,7 +4,6 @@ import MapboxGL, { FullscreenControl, Layer, Source } from "react-map-gl";
 import "mapbox-gl/dist/mapbox-gl.css";
 import { Waypoint } from 'react-waypoint';
 
-import { dataSource } from "./data";
 import { generateKeyframes } from "./keyframes";
 import { baseMap, extrusion } from "./styles";
 
@@ -29,8 +28,8 @@ export default class FluMap extends React.Component {
           mapboxApiAccessToken={MAPBOX_ACCESS_TOKEN}>
 
           {
-            this.getState("dataSource") &&
-              <Source type="geojson" data={this.getState("dataSource")}>
+            this.props.dataSource &&
+              <Source type="geojson" data={this.props.dataSource}>
                 <Layer beforeId="waterway-label"
                     type="fill-extrusion"
                     paint={extrusion(this.props.date)} />
@@ -81,18 +80,9 @@ export default class FluMap extends React.Component {
     this._did_mount = resolve;
   });
 
-  async componentDidMount() {
-    this._did_mount();
-
-    try {
-      const geojson = await dataSource();
-      console.debug("Fetched data source:", geojson.toJS());
-
-      this.newState(s => s.set("dataSource", geojson));
-    }
-    catch(err) {
-      console.error(`Unable to load data source:`, err);
-      return;
+  componentDidUpdate(prevProps) {
+    if (this.props.dataSource != prevProps.dataSource) {
+      this._did_mount();
     }
   }
 

--- a/current/src/components/FluMap/styles.js
+++ b/current/src/components/FluMap/styles.js
@@ -4,7 +4,7 @@ import { flatten } from "lodash";
 import heatmap from "./heatmap.json";
 import mapboxDark from "./mapbox-dark-v10.json";
 
-const missingDataColor = "#777777";
+export const missingDataColor = "#777777";
 
 /**
  * Mapping of "intensity" to color encoded in heatmap.json

--- a/current/src/components/SeasonTimeline.js
+++ b/current/src/components/SeasonTimeline.js
@@ -18,12 +18,13 @@ export default class SeasonTimeline extends React.Component {
   componentDidUpdate(prevProps) {
     if (this.props.date !== prevProps.date) {
       if (this.state.displayWeeks.includes(this.props.date)) {
-        this.setState({ displayDate: this.props.date })
+        this.setState({ displayDate: this.props.date });
       }
       else {
+        const startWithCurrentDate = this.props.date < this.state.currentDate && this.props.date.weekNumber !== this.state.currentDate.weekNumber;
         this.setState({
           displayDate: this.props.date,
-          displayWeeks: generateWeeks(this.props.date, this.props.date < this.state.currentDate)
+          displayWeeks: generateWeeks(this.props.date, startWithCurrentDate)
         });
       }
     }
@@ -193,7 +194,7 @@ export default class SeasonTimeline extends React.Component {
  */
 function generateWeeks(currentDate, startWithCurrentDate = false) {
   // Default is to set start date to 6 months ago
-  const startDateTime = startWithCurrentDate ? currentDate : currentDate.minus({ months: 6 });
+  const startDateTime = startWithCurrentDate ? currentDate : currentDate.minus({ weeks: 26 });
 
   return _.range(27)
           .map(i => startDateTime.plus({ weeks: i }));

--- a/current/src/components/SeasonTimeline.js
+++ b/current/src/components/SeasonTimeline.js
@@ -62,7 +62,7 @@ export default class SeasonTimeline extends React.Component {
     const currentWeek = this.state.displayDate.toFormat("kkkk-'W'WW")
     const currentWeekIndex = weeks.findIndex(w => w.toFormat("kkkk-'W'WW") === currentWeek);
 
-    const [width, height, margin] = [800, 160, 5];
+    const [width, height, margin] = [800, 200, 5];
 
     // The months are packed chevrons.  First calculate the space for each
     // month as a rectangle.  Then subtract from that the width of one chevron
@@ -103,31 +103,52 @@ export default class SeasonTimeline extends React.Component {
           A timeline detailing flu circulation from approximately six
           months ago to the current week.
         </desc>
-        <g transform={`translate(${margin}, ${height - weekHeight})`}>
-          {weeks.map((w, i) =>
-          <g key={w.toFormat("kkkk-'W'WW")}
-             transform={`translate(${i * weekWidth}, 0)`}
-             style={{ pointerEvents: "bounding-box", cursor: "pointer" }}
-             onClick={() => this.props.updateCurrentDate(w)}>
-              <polygon points={`0, 0
-                              ${weekWidth},0
-                              ${weekWidth * (1 + chevronOutset)}, ${weekHeight / 2}
-                              ${weekWidth}, ${weekHeight}
-                              0, ${weekHeight}
-                              ${weekWidth * chevronOutset}, ${weekHeight / 2}`}
-                    fill={(fluIntensityByWeek && colorMap) ? colorMap[fluIntensityByWeek[w.toFormat("kkkk-'W'WW")]] : missingDataColor}
-                    stroke="white" />
+        <g transform={`translate(${margin}, ${height - weekHeight - 40})`}>
+          {weeks.map((w, i) => {
+            let displayMonth = true;
+            // Only display a month label for the first week within the month
+            if (i !== 0 && w.month === weeks[i-1].month) {
+              displayMonth = false;
+            }
+            return (
+              <g key={w.toFormat("kkkk-'W'WW")}
+               transform={`translate(${i * weekWidth}, 0)`}
+               style={{ pointerEvents: "bounding-box", cursor: "pointer" }}
+               onClick={() => this.props.updateCurrentDate(w)}>
+                <polygon points={`0, 0
+                                ${weekWidth},0
+                                ${weekWidth * (1 + chevronOutset)}, ${weekHeight / 2}
+                                ${weekWidth}, ${weekHeight}
+                                0, ${weekHeight}
+                                ${weekWidth * chevronOutset}, ${weekHeight / 2}`}
+                      fill={(fluIntensityByWeek && colorMap) ? colorMap[fluIntensityByWeek[w.toFormat("kkkk-'W'WW")]] : missingDataColor}
+                      stroke="white" />
 
-              <text textAnchor="middle"
-                    dominantBaseline="middle"
-                    x={weekWidth * 0.65}
-                    y={weekHeight / 2 + 5}
-                    dy="-3px"
-                    style={{fontWeight: i === currentWeekIndex ? "bold" : "normal"}}>
-                {w.weekNumber}
-              </text>
-            </g>
-          )}
+                <text textAnchor="middle"
+                      dominantBaseline="middle"
+                      x={weekWidth * 0.65}
+                      y={weekHeight / 2 + 5}
+                      dy="-3px"
+                      style={{fontWeight: i === currentWeekIndex ? "bold" : "normal"}}>
+                  {w.weekNumber}
+                </text>
+
+                {displayMonth &&
+                  <g transform={`translate(0, ${height - weekHeight * 1.85})`}>
+                    <line x1={weekWidth * 0.65} y1="0" x2={weekWidth * 0.65} y2={weekHeight / 2.5} style={{stroke: "black", strokeWidth: 2}}/>
+                    <text textAnchor="middle"
+                          dominantBaseline="middle"
+                          x={weekWidth * 0.65}
+                          y={weekHeight / 2 + 5}
+                          dy="-3px"
+                          style={{fontWeight: w.month === this.state.displayDate.month ? "bold" : "normal"}}>
+                      {w.monthShort}
+                    </text>
+                  </g>
+                }
+              </g>
+            )
+          })}
         </g>
 
         <g key="current-week-virus-pin"

--- a/current/src/components/SeasonTimeline.js
+++ b/current/src/components/SeasonTimeline.js
@@ -44,7 +44,7 @@ export default class SeasonTimeline extends React.Component {
 
     const weekHeight = 70;
 
-    const iconDimensions = Math.min(weekWidth, "50");
+    const iconDimensions = Math.min((weekWidth+20), "50");
     const pinheadRadius = iconDimensions / 1.5;
 
     const pinHeight = height - weekHeight - pinheadRadius;
@@ -68,7 +68,8 @@ export default class SeasonTimeline extends React.Component {
            width="100%"
            height={height + margin * 2}
            role="img"
-           aria-labelledby="fluSeasonTimelineID fluSeasonTimelineDescID">
+           aria-labelledby="fluSeasonTimelineID fluSeasonTimelineDescID"
+           style={{ overflow: "visible" }}>
         <title id="fluSeasonTimelineID">Flu Season Timeline</title>
         <desc id="fluSeasonTimelineDescID">
           A timeline detailing flu circulation from approximately six

--- a/current/src/components/SeasonTimeline.js
+++ b/current/src/components/SeasonTimeline.js
@@ -7,23 +7,30 @@ import fluIcon from '../img/flu-virus-green.svg';
 
 export default class SeasonTimeline extends React.Component {
   state = {
-    currentDate: this.props.date,
-    weeks: generateWeeks(this.props.date)
+    currentDate: DateTime.local(),
+    currentWeeks: generateWeeks(DateTime.local()),
+    displayDate: this.props.date,
+    displayWeeks: generateWeeks(this.props.date)
   }
 
   componentDidUpdate(prevProps) {
-    if (this.props.date !== prevProps.date && !this.state.weeks.includes(this.props.date)) {
-      this.setState({
-        currentDate: this.props.date,
-        weeks: generateWeeks(this.props.date, this.props.date < this.state.currentDate)
-      });
+    if (this.props.date !== prevProps.date) {
+      if (this.state.displayWeeks.includes(this.props.date)) {
+        this.setState({ displayDate: this.props.date })
+      }
+      else {
+        this.setState({
+          displayDate: this.props.date,
+          displayWeeks: generateWeeks(this.props.date, this.props.date < this.state.currentDate)
+        });
+      }
     }
   }
 
   render() {
-    const weeks = this.state.weeks.map(w => ({"month": w.month, "weekNumber": w.weekNumber, "week": w.toFormat("kkkk-'W'WW")}));
-    const currentWeek = this.state.currentDate.toFormat("kkkk-'W'WW")
-    const currentWeekIndex = weeks.findIndex(w => w.week === currentWeek);
+    const weeks = this.state.displayWeeks;
+    const currentWeek = this.state.displayDate.toFormat("kkkk-'W'WW")
+    const currentWeekIndex = weeks.findIndex(w => w.toFormat("kkkk-'W'WW") === currentWeek);
 
     const [width, height, margin] = [800, 160, 5];
 
@@ -61,8 +68,7 @@ export default class SeasonTimeline extends React.Component {
            width="100%"
            height={height + margin * 2}
            role="img"
-           aria-labelledby="fluSeasonTimelineID fluSeasonTimelineDescID"
-           style={{pointerEvents: "none"}}>
+           aria-labelledby="fluSeasonTimelineID fluSeasonTimelineDescID">
         <title id="fluSeasonTimelineID">Flu Season Timeline</title>
         <desc id="fluSeasonTimelineDescID">
           A timeline detailing flu circulation from approximately six
@@ -70,8 +76,10 @@ export default class SeasonTimeline extends React.Component {
         </desc>
         <g transform={`translate(${margin}, ${height - weekHeight})`}>
           {weeks.map((w, i) =>
-          <g key={w.week}
-             transform={`translate(${i * weekWidth}, 0)`}>
+          <g key={w.toFormat("kkkk-'W'WW")}
+             transform={`translate(${i * weekWidth}, 0)`}
+             style={{ pointerEvents: "bounding-box", cursor: "pointer" }}
+             onClick={() => this.props.updateCurrentDate(w)}>
               <polygon points={`0, 0
                               ${weekWidth},0
                               ${weekWidth * (1 + chevronOutset)}, ${weekHeight / 2}

--- a/current/src/components/SeasonTimeline.js
+++ b/current/src/components/SeasonTimeline.js
@@ -148,10 +148,10 @@ export default class SeasonTimeline extends React.Component {
 
                   <text textAnchor="middle"
                         dominantBaseline="middle"
-                        x={weekWidth * 0.65}
+                        x={weekWidth * 0.7}
                         y={weekHeight / 2 + 5}
                         dy="-3px"
-                        style={{fontWeight: i === displayWeekIndex ? "bold" : "normal"}}>
+                        style={{fill: "white", fontWeight: i === displayWeekIndex ? "bold" : "normal"}}>
                     {w.weekNumber}
                   </text>
 
@@ -162,8 +162,7 @@ export default class SeasonTimeline extends React.Component {
                             dominantBaseline="middle"
                             x={weekWidth * offset}
                             y={weekHeight / 3 + 10}
-                            dy="-3px"
-                            style={{fontWeight: w.month === this.state.displayDate.month ? "bold" : "normal"}}>
+                            dy="-3px">
                         {weeks[i+1].monthShort}
                       </text>
                     </g>

--- a/current/src/components/SeasonTimeline.js
+++ b/current/src/components/SeasonTimeline.js
@@ -52,16 +52,20 @@ export default class SeasonTimeline extends React.Component {
   }
 
   render() {
+    const weeks = this.state.displayWeeks;
+    const currentWeek = this.state.currentDate.toFormat("kkkk-'W'WW");
+    const displayWeek = this.state.displayDate.toFormat("kkkk-'W'WW");
+
     let fluIntensityByWeek;
     let colorMap;
+    let currentFluIntensity;
     if (this.props.dataSource) {
       fluIntensityByWeek = this.parseDataSource();
       colorMap = Object.assign(...heatmap.map(([intensity, color]) => ({[intensity]: color})))
+      currentFluIntensity = getFluIntensityLanguage(fluIntensityByWeek, displayWeek)
     }
 
-    const weeks = this.state.displayWeeks;
-    const currentWeek = this.state.displayDate.toFormat("kkkk-'W'WW")
-    const currentWeekIndex = weeks.findIndex(w => w.toFormat("kkkk-'W'WW") === currentWeek);
+    const displayWeekIndex = weeks.findIndex(w => w.toFormat("kkkk-'W'WW") === displayWeek);
 
     const [width, height, margin] = [800, 200, 5];
 
@@ -93,88 +97,97 @@ export default class SeasonTimeline extends React.Component {
     `
 
     return (
-      <svg viewBox={`0 0 ${width + margin * 2} ${height + margin * 2}`}
-           width="100%"
-           height={height + margin * 2}
-           role="img"
-           aria-labelledby="fluSeasonTimelineID fluSeasonTimelineDescID"
-           style={{ overflow: "visible" }}>
-        <title id="fluSeasonTimelineID">Flu Season Timeline</title>
-        <desc id="fluSeasonTimelineDescID">
-          A timeline detailing flu circulation from approximately six
-          months ago to the current week.
-        </desc>
-        <g transform={`translate(${margin}, ${height - weekHeight - 40})`}>
-          {weeks.map((w, i) => {
-            let displayMonth = true;
-            // Only display a month label for the first week within the month
-            if (i !== 0 && w.month === weeks[i-1].month) {
-              displayMonth = false;
-            }
-            return (
-              <g key={w.toFormat("kkkk-'W'WW")}
-               transform={`translate(${i * weekWidth}, 0)`}
-               style={{ pointerEvents: "bounding-box", cursor: "pointer" }}
-               onClick={() => this.props.updateCurrentDate(w)}>
-                <polygon points={`0, 0
-                                ${weekWidth},0
-                                ${weekWidth * (1 + chevronOutset)}, ${weekHeight / 2}
-                                ${weekWidth}, ${weekHeight}
-                                0, ${weekHeight}
-                                ${weekWidth * chevronOutset}, ${weekHeight / 2}`}
-                      fill={(fluIntensityByWeek && colorMap) ? colorMap[fluIntensityByWeek[w.toFormat("kkkk-'W'WW")]] : missingDataColor}
-                      stroke="white" />
+      <>
+        <p style={{ textAlign: "center" }}>
+          In the
+          {currentWeek === displayWeek
+            ? ` current week (${displayWeek}), `
+            : ` week of ${displayWeek}, `}
+          overall flu circulation is estimated to be <b>{currentFluIntensity}</b>.
+        </p>
+        <svg viewBox={`0 0 ${width + margin * 2} ${height + margin * 2}`}
+             width="100%"
+             height={height + margin * 2}
+             role="img"
+             aria-labelledby="fluSeasonTimelineID fluSeasonTimelineDescID"
+             style={{ overflow: "visible" }}>
+          <title id="fluSeasonTimelineID">Flu Season Timeline</title>
+          <desc id="fluSeasonTimelineDescID">
+            A timeline detailing flu circulation from approximately six
+            months ago to the current week.
+          </desc>
+          <g transform={`translate(${margin}, ${height - weekHeight - 40})`}>
+            {weeks.map((w, i) => {
+              let displayMonth = true;
+              // Only display a month label for the first week within the month
+              if (i !== 0 && w.month === weeks[i-1].month) {
+                displayMonth = false;
+              }
+              return (
+                <g key={w.toFormat("kkkk-'W'WW")}
+                 transform={`translate(${i * weekWidth}, 0)`}
+                 style={{ pointerEvents: "bounding-box", cursor: "pointer" }}
+                 onClick={() => this.props.updateCurrentDate(w)}>
+                  <polygon points={`0, 0
+                                  ${weekWidth},0
+                                  ${weekWidth * (1 + chevronOutset)}, ${weekHeight / 2}
+                                  ${weekWidth}, ${weekHeight}
+                                  0, ${weekHeight}
+                                  ${weekWidth * chevronOutset}, ${weekHeight / 2}`}
+                        fill={(fluIntensityByWeek && colorMap) ? colorMap[fluIntensityByWeek[w.toFormat("kkkk-'W'WW")]] : missingDataColor}
+                        stroke="white" />
 
-                <text textAnchor="middle"
-                      dominantBaseline="middle"
-                      x={weekWidth * 0.65}
-                      y={weekHeight / 2 + 5}
-                      dy="-3px"
-                      style={{fontWeight: i === currentWeekIndex ? "bold" : "normal"}}>
-                  {w.weekNumber}
-                </text>
+                  <text textAnchor="middle"
+                        dominantBaseline="middle"
+                        x={weekWidth * 0.65}
+                        y={weekHeight / 2 + 5}
+                        dy="-3px"
+                        style={{fontWeight: i === displayWeekIndex ? "bold" : "normal"}}>
+                    {w.weekNumber}
+                  </text>
 
-                {displayMonth &&
-                  <g transform={`translate(0, ${height - weekHeight * 1.85})`}>
-                    <line x1={weekWidth * 0.65} y1="0" x2={weekWidth * 0.65} y2={weekHeight / 2.5} style={{stroke: "black", strokeWidth: 2}}/>
-                    <text textAnchor="middle"
-                          dominantBaseline="middle"
-                          x={weekWidth * 0.65}
-                          y={weekHeight / 2 + 5}
-                          dy="-3px"
-                          style={{fontWeight: w.month === this.state.displayDate.month ? "bold" : "normal"}}>
-                      {w.monthShort}
-                    </text>
-                  </g>
-                }
-              </g>
-            )
-          })}
-        </g>
+                  {displayMonth &&
+                    <g transform={`translate(0, ${height - weekHeight * 1.85})`}>
+                      <line x1={weekWidth * 0.65} y1="0" x2={weekWidth * 0.65} y2={weekHeight / 2.5} style={{stroke: "black", strokeWidth: 2}}/>
+                      <text textAnchor="middle"
+                            dominantBaseline="middle"
+                            x={weekWidth * 0.65}
+                            y={weekHeight / 2 + 5}
+                            dy="-3px"
+                            style={{fontWeight: w.month === this.state.displayDate.month ? "bold" : "normal"}}>
+                        {w.monthShort}
+                      </text>
+                    </g>
+                  }
+                </g>
+              )
+            })}
+          </g>
 
-        <g key="current-week-virus-pin"
-           transform={`translate(${currentWeekIndex * weekWidth + weekWidth * 0.65}, ${pinheadRadius})`}>
-          <path
-            d={`
-              M ${-(pinheadRadius - 5)} 18
-              A ${pinheadRadius} ${pinheadRadius} 220 1 1 ${pinheadRadius - 5} 18
-              L 0 ${pinheadRadius * 2}
-              z
-            `}
-            fill="#1bab4c"
-            strokeWidth="2"
-            strokeLinecap="round" />
-          <Spin>
-            <image href={fluIcon}
-                  y={-iconDimensions / 2}
-                  x={-iconDimensions / 2}
-                  width={iconDimensions}
-                  height={iconDimensions}
-                  style={{opacity: 0.9}} />
-          </Spin>
-        </g>
+          <g key="current-week-virus-pin"
+             transform={`translate(${displayWeekIndex * weekWidth + weekWidth * 0.65}, ${pinheadRadius})`}>
+            <path
+              d={`
+                M ${-(pinheadRadius - 5)} 18
+                A ${pinheadRadius} ${pinheadRadius} 220 1 1 ${pinheadRadius - 5} 18
+                L 0 ${pinheadRadius * 2}
+                z
+              `}
+              fill="#1bab4c"
+              strokeWidth="2"
+              strokeLinecap="round" />
+            <Spin>
+              <image href={fluIcon}
+                    y={-iconDimensions / 2}
+                    x={-iconDimensions / 2}
+                    width={iconDimensions}
+                    height={iconDimensions}
+                    style={{opacity: 0.9}} />
+            </Spin>
+          </g>
 
-      </svg>
+        </svg>
+      </>
     );
   }
 }
@@ -198,4 +211,35 @@ function generateWeeks(currentDate, startWithCurrentDate = false) {
 
   return _.range(27)
           .map(i => startDateTime.plus({ weeks: i }));
+}
+
+/**
+ * This helper function is use to determine the appropriate language describing the
+ * flu circulation of a given week. The language is borrowed from the ColorRamp legend.
+ *
+ * @param {Object} fluIntensityByWeek - An object that holds the average flu intensity within
+ * the general Seattle area for each week.
+ * @param {String} displayWeek - A string representing the current week displayed in the format
+ * of 2019-W01
+ * @return {String} A string describing the flu circulation levels (minimal, low, moderate, high)
+ */
+function getFluIntensityLanguage(fluIntensityByWeek, displayWeek) {
+  let currentFluIntensity = fluIntensityByWeek[displayWeek];
+
+  if (currentFluIntensity === undefined) return 'unknown';
+
+  if (currentFluIntensity < 0.06) {
+    currentFluIntensity = 'minimal';
+  }
+  else if (currentFluIntensity < 0.12) {
+    currentFluIntensity = 'low';
+  }
+  else if (currentFluIntensity < 0.18) {
+    currentFluIntensity = 'moderate';
+  }
+  else {
+    currentFluIntensity = 'high';
+  }
+
+  return currentFluIntensity
 }

--- a/current/src/components/SeasonTimeline.js
+++ b/current/src/components/SeasonTimeline.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { DateTime } from 'luxon';
+import { DateTime, Interval } from 'luxon';
 import _ from 'lodash';
 import styled, { keyframes } from 'styled-components';
 
@@ -118,10 +118,19 @@ export default class SeasonTimeline extends React.Component {
           </desc>
           <g transform={`translate(${margin}, ${height - weekHeight - 40})`}>
             {weeks.map((w, i) => {
-              let displayMonth = true;
+              let displayMonth = false;
+              let offset = 0;
               // Only display a month label for the first week within the month
-              if (i !== 0 && w.month === weeks[i-1].month) {
-                displayMonth = false;
+              // The month label should be displayed in the week during which
+              // the first of the month occurs.
+              if (weeks[i+1]) {
+                if (i !== 0 && w.month !== weeks[i+1].month) {
+                  displayMonth = true;
+                  // Compute offset, ie how far into this week was the 1st of
+                  // the month?
+                  const nextMonth = DateTime.local(weeks[i+1].year, weeks[i+1].month, 1)
+                  offset = Interval.fromDateTimes(w, nextMonth).length('weeks', true)
+                }
               }
               return (
                 <g key={w.toFormat("kkkk-'W'WW")}
@@ -148,14 +157,14 @@ export default class SeasonTimeline extends React.Component {
 
                   {displayMonth &&
                     <g transform={`translate(0, ${height - weekHeight * 1.85})`}>
-                      <line x1={weekWidth * 0.65} y1="0" x2={weekWidth * 0.65} y2={weekHeight / 2.5} style={{stroke: "black", strokeWidth: 2}}/>
+                      <line x1={weekWidth * offset} y1="1" x2={weekWidth * offset} y2={weekHeight / 3 - 1} style={{stroke: "black", strokeWidth: 2}}/>
                       <text textAnchor="middle"
                             dominantBaseline="middle"
-                            x={weekWidth * 0.65}
-                            y={weekHeight / 2 + 5}
+                            x={weekWidth * offset}
+                            y={weekHeight / 3 + 10}
                             dy="-3px"
                             style={{fontWeight: w.month === this.state.displayDate.month ? "bold" : "normal"}}>
-                        {w.monthShort}
+                        {weeks[i+1].monthShort}
                       </text>
                     </g>
                   }


### PR DESCRIPTION
Makes the season timeline an interactive timeline where clicking on each week will change the map displayed.

The timeline is also colored with the same color scheme as the map to indicate the general flu circulation for the week. This aggregates the flu circulation of all the regions with a simple average. (@seattleflu/idm may provide this via the API in the future, see [slack](https://seattle-flu-study.slack.com/archives/CE9B78CS0/p1576801301008100)).