### PR TITLE
Add Pathogens page

### DIFF
--- a/app.js
+++ b/app.js
@@ -41,6 +41,7 @@ var appleRouter = require('./routes/apple');
 var appleFaqRouter = require('./routes/applestudyfaq');
 var applePdfRouter = require('./routes/apple-pdf');
 var researchRouter = require ('./routes/research');
+var pathogensRouter = require ('./routes/pathogens');
 
 const production = process.env.NODE_ENV === 'production';
 
@@ -98,6 +99,7 @@ app.use ('/privacy', privacyRouter);
 app.use ('/households', householdsRouter);
 app.use ('/welcome', welcomeRouter);
 app.use ('/research', researchRouter);
+app.use ('/pathogens', pathogensRouter);
 
 app.use ('/uw/start', function (req, res) {
   res.redirect (302, 'https://backoffice.seattleflu.org/husky-musher');

--- a/routes/pathogens.js
+++ b/routes/pathogens.js
@@ -1,0 +1,67 @@
+var express = require('express')
+var router = express.Router()
+
+var page = require('../services/page')
+var site = require('../services/site')
+
+router.use((req, res, next) => {
+  site
+    .getSiteData()
+    .then(siteData => {
+      req.siteData = siteData.items
+      next()
+    })
+    .catch(console.error)
+})
+
+var md = require('markdown-it')({
+  html: true
+})
+var markdownItAttrs = require('markdown-it-attrs')
+
+router.use((req, res, next) => {
+  page
+    .getPageData('pathogens')
+    .then(pageData => {
+      req.pageData = pageData.items
+      if(pageData.items[0].fields.showMenu != null){
+        var nav = pageData.items[0].fields.showMenu
+        req.nav = nav.toString();
+      }else{
+        req.nav = 'true'
+      }
+
+      if(pageData.items[0].fields.showJoinTheStudyAfterMenu != null){
+        var enroll = pageData.items[0].fields.showJoinTheStudyAfterMenu
+        req.enroll = enroll.toString();
+      }else{
+        req.enroll = 'true'
+      }
+      next()
+    })
+    .catch(console.error)
+})
+
+router.get('/', function(req,res,next){
+  var baseUrl = req.get('host')
+  var pageUrl = req.baseUrl;
+  req.pageUrl =  baseUrl + pageUrl
+  next()
+})
+
+/* GET home page. */
+router.get('/', function (req, res, next) {
+  res.render('pathogens', {
+    title: 'Pathogens',
+    header: 'light',
+    nav: req.nav,
+    enroll: req.enroll,
+    logos: 'true',
+    md: md,
+    pageData: req.pageData,
+    siteData: req.siteData,
+    pageUrl:req.pageUrl
+  })
+})
+
+module.exports = router

--- a/views/pathogens.ejs
+++ b/views/pathogens.ejs
@@ -1,0 +1,57 @@
+<% include ./partials/header  {header: header, pageData: req.pageData, siteData: req.siteData, nav: nav, enroll: enroll} %>
+
+<div class="secondary container">
+    <div class="row">
+        <div class="col-12">
+            <h1><%= pageData[0].fields.name %></h1>
+            <h3><%= pageData[0].fields.subhead %></h3>
+            <div><%- md.render(pageData[0].fields.content) %></div>
+
+            <!-- start of embed of Observable notebook -->
+            <div id="observablehq-chart"></div>
+            <div id="observablehq-caption"></div>
+
+            <script type="module">
+              import {Runtime, Inspector, Library} from "https://cdn.jsdelivr.net/npm/@observablehq/runtime@4/dist/runtime.js";
+              import notebook from "https://api.observablehq.com/@tsibley/pathogen-prevalence.js?v=3";
+
+              const chart = document.querySelector("#observablehq-chart");
+              const caption = document.querySelector("#observablehq-caption");
+
+              const library = new Library();
+              const runtime = new Runtime(library);
+
+              const main = new Runtime().module(notebook, name => {
+                if (name === "viewof chart") return new Inspector(chart);
+                if (name === "caption") return new Inspector(caption);
+              });
+
+              /* "width" defaults to the window's clientWidth, which is wider
+               * than our body content container.  Redefine "width" as a
+               * generator that yields the chart element's clientWidth (if
+               * changed) whenever a resize is observed.
+               *
+               * Based on:
+               *   <https://github.com/observablehq/examples/blob/main/custom-fluid-width/index.html>
+               *   <https://github.com/observablehq/examples/blob/main/custom-fluid-width-and-height/index.html>
+               */
+              main.redefine("width", library.Generators.observe(notify => {
+                let value = notify(chart.getBoundingClientRect().width); // initial value
+                const observer = new ResizeObserver(([entry]) => {
+                  const newValue = entry.contentRect.width;
+                  if (newValue !== value) {
+                    notify(value = newValue);
+                  }
+                });
+                observer.observe(chart);
+                return () => observer.disconnect();
+              }));
+            </script>
+            <!-- end embed -->
+
+            <div><%- md.render(pageData[0].fields.content2) %></div>
+        </div>
+    </div>
+</div>
+
+<% include ./partials/footer  {logos: logos}%>


### PR DESCRIPTION
Embeds a chart and caption from an Observable notebook.¹  Other page
data comes from Contentful, as usual.

Embedding from Observable was the quickest way to get this page
together.  It's not my normal approach, but I think it'll be the most
maintenance-free approach.  We _could_ extract the code in the notebook
and use it directly in the website here, but we'd lose (or have to
re-implement) things like auto-resizing, dep management, and other
things that Observable handles for us.  It's just more overhead, for
benefit I'm not sure we need.

The notebook is currently associated with my personal Observable
account, but we can remedy this in the (near) future by forking the
notebook elsewhere (a shared "personal" account or an Observable team
account) and updating the embed URL here to point to the fork.  I didn't
want to block getting the page up on resolving the notebook ownership.

I've created and published the "Pathogens" page in the "prod"
environment in Contentful since it won't affect the live site and makes
previewing in dev easy.  Once this commit is deployed, we'll want to add
the Pathogens page to the menu as well, which is managed in Contentful.

Except for the embedding code, the rest of the changes here are the
copypasta that's typical for this repo.

¹ https://observablehq.com/@tsibley/pathogen-prevalence